### PR TITLE
Stop the ansi madness

### DIFF
--- a/src/main/java/net/neoforged/waifu/logback/DiscordLogbackLayout.java
+++ b/src/main/java/net/neoforged/waifu/logback/DiscordLogbackLayout.java
@@ -51,6 +51,12 @@ public class DiscordLogbackLayout extends LayoutBase<ILoggingEvent> {
 
             final StringBuilder stacktrace = buildStacktrace(t);
             String stacktraceCutoff = null;
+
+            if (stacktrace.toString().isBlank()) {
+                builder.append("StackTrace is blank <:thonk:932605815221788672>");
+                return builder.toString();
+            }
+
             builder.append("Stacktrace: ");
             if (stacktrace.length() > MAXIMUM_STACKTRACE_LENGTH) {
                 stacktraceCutoff = stacktrace.substring(MAXIMUM_STACKTRACE_LENGTH, stacktrace.length());


### PR DESCRIPTION
If the stacktrace has no visible contents, give up and stop printing ```ansi```